### PR TITLE
fix: hotkeys stop working and are not displayed after switching language

### DIFF
--- a/UIFunc.py
+++ b/UIFunc.py
@@ -303,6 +303,9 @@ class UIFunc(QMainWindow, Ui_UIView, QtStyleTools):
             _app.installTranslator(self.trans)
             self.retranslateUi(self)
         self.retranslateUi(self)
+        self.hotkey_stop.setText(self.config.value("Config/StopHotKey"))
+        self.hotkey_start.setText(self.config.value("Config/StartHotKey"))
+        self.hotkey_record.setText(self.config.value("Config/RecordHotKey"))
 
     def onchangetheme(self):
         theme = self.choice_theme.currentText()


### PR DESCRIPTION
切换语言后热键显示消失并且按下后没有反应，修改了UIFunc.py下的onchangelang()函数使得切换语言后重新设定热键值
